### PR TITLE
bump versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "imgui-glfw-support"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Aaron Loucks <aloucks@cofront.net>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -11,14 +11,14 @@ keywords = ["imgui", "glfw", "wgpu"]
 description = "GLFW support for imgui-rs"
 
 [dependencies]
-glfw = "0.36"
-imgui = "0.3"
+glfw = "0.37"
+imgui = "0.4"
 
 [features]
 vulkan = ["glfw/vulkan"]
 image = ["glfw/image"]
 
 [dev-dependencies]
-wgpu = "0.4"
-imgui-wgpu = "0.5"
-imgui = "0.3"
+wgpu = "0.5"
+imgui-wgpu = "0.7"
+imgui = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,4 @@ image = ["glfw/image"]
 wgpu = "0.5"
 imgui-wgpu = "0.7"
 imgui = "0.4"
+futures = "0.3.4"

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ GLFW support for [imgui-rs](https://github.com/Gekkio/imgui-rs).
 
 ```rust
 use std::time::Instant;
+
 use futures::executor::block_on;
 
 fn main() {
@@ -28,25 +29,21 @@ fn main() {
 
     let surface = wgpu::Surface::create(&window);
 
-    let adapter = block_on(
-        wgpu::Adapter::request(
-            &wgpu::RequestAdapterOptions {
-                power_preference: wgpu::PowerPreference::HighPerformance,
-                compatible_surface: Some(&surface)
-            },
-            wgpu::BackendBit::PRIMARY,
-        )
-    ).unwrap();
+    let adapter = block_on(wgpu::Adapter::request(
+        &wgpu::RequestAdapterOptions {
+            power_preference: wgpu::PowerPreference::HighPerformance,
+            compatible_surface: Some(&surface),
+        },
+        wgpu::BackendBit::PRIMARY,
+    ))
+    .unwrap();
 
-
-    let (device, mut queue) = block_on(
-        adapter.request_device(&wgpu::DeviceDescriptor {
-            extensions: wgpu::Extensions {
-                anisotropic_filtering: false,
-            },
-            limits: wgpu::Limits::default(),
-        })
-    );
+    let (device, mut queue) = block_on(adapter.request_device(&wgpu::DeviceDescriptor {
+        extensions: wgpu::Extensions {
+            anisotropic_filtering: false,
+        },
+        limits: wgpu::Limits::default(),
+    }));
 
     let mut swap_chain_desc = wgpu::SwapChainDescriptor {
         usage: wgpu::TextureUsage::OUTPUT_ATTACHMENT,
@@ -129,7 +126,8 @@ fn main() {
             glfw_platform.prepare_render(&ui, &mut window);
         }
 
-        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
+        let mut encoder =
+            device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
         imgui_renderer
             .render(ui.render(), &device, &mut encoder, &frame.view)
             .expect("render failed");

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ GLFW support for [imgui-rs](https://github.com/Gekkio/imgui-rs).
 
 ```rust
 use std::time::Instant;
+use futures::executor::block_on;
 
 fn main() {
     let mut glfw = glfw::init(glfw::FAIL_ON_ERRORS).expect("GLFW failed to init");
@@ -27,25 +28,32 @@ fn main() {
 
     let surface = wgpu::Surface::create(&window);
 
-    let adapter = wgpu::Adapter::request(&wgpu::RequestAdapterOptions {
-        power_preference: wgpu::PowerPreference::HighPerformance,
-        backends: wgpu::BackendBit::PRIMARY,
-    })
-    .unwrap();
+    let adapter = block_on(
+        wgpu::Adapter::request(
+            &wgpu::RequestAdapterOptions {
+                power_preference: wgpu::PowerPreference::HighPerformance,
+                compatible_surface: Some(&surface)
+            },
+            wgpu::BackendBit::PRIMARY,
+        )
+    ).unwrap();
 
-    let (device, mut queue) = adapter.request_device(&wgpu::DeviceDescriptor {
-        extensions: wgpu::Extensions {
-            anisotropic_filtering: false,
-        },
-        limits: wgpu::Limits::default(),
-    });
+
+    let (device, mut queue) = block_on(
+        adapter.request_device(&wgpu::DeviceDescriptor {
+            extensions: wgpu::Extensions {
+                anisotropic_filtering: false,
+            },
+            limits: wgpu::Limits::default(),
+        })
+    );
 
     let mut swap_chain_desc = wgpu::SwapChainDescriptor {
         usage: wgpu::TextureUsage::OUTPUT_ATTACHMENT,
         format: wgpu::TextureFormat::Bgra8Unorm,
         width,
         height,
-        present_mode: wgpu::PresentMode::NoVsync,
+        present_mode: wgpu::PresentMode::Immediate,
     };
 
     let mut swap_chain = device.create_swap_chain(&surface, &swap_chain_desc);
@@ -105,7 +113,7 @@ fn main() {
             swap_chain = device.create_swap_chain(&surface, &swap_chain_desc);
         }
 
-        let frame = swap_chain.get_next_texture();
+        let frame = swap_chain.get_next_texture().unwrap();
         last_frame_time = imgui.io_mut().update_delta_time(last_frame_time);
 
         glfw_platform
@@ -121,7 +129,7 @@ fn main() {
             glfw_platform.prepare_render(&ui, &mut window);
         }
 
-        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
+        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
         imgui_renderer
             .render(ui.render(), &device, &mut encoder, &frame.view)
             .expect("render failed");

--- a/examples/demo_window.rs
+++ b/examples/demo_window.rs
@@ -1,4 +1,5 @@
 use std::time::Instant;
+
 use futures::executor::block_on;
 
 fn main() {
@@ -15,25 +16,21 @@ fn main() {
 
     let surface = wgpu::Surface::create(&window);
 
-    let adapter = block_on(
-        wgpu::Adapter::request(
-            &wgpu::RequestAdapterOptions {
-                power_preference: wgpu::PowerPreference::HighPerformance,
-                compatible_surface: Some(&surface)
-            },
-            wgpu::BackendBit::PRIMARY,
-        )
-    ).unwrap();
+    let adapter = block_on(wgpu::Adapter::request(
+        &wgpu::RequestAdapterOptions {
+            power_preference: wgpu::PowerPreference::HighPerformance,
+            compatible_surface: Some(&surface),
+        },
+        wgpu::BackendBit::PRIMARY,
+    ))
+    .unwrap();
 
-
-    let (device, mut queue) = block_on(
-        adapter.request_device(&wgpu::DeviceDescriptor {
-            extensions: wgpu::Extensions {
-                anisotropic_filtering: false,
-            },
-            limits: wgpu::Limits::default(),
-        })
-    );
+    let (device, mut queue) = block_on(adapter.request_device(&wgpu::DeviceDescriptor {
+        extensions: wgpu::Extensions {
+            anisotropic_filtering: false,
+        },
+        limits: wgpu::Limits::default(),
+    }));
 
     let mut swap_chain_desc = wgpu::SwapChainDescriptor {
         usage: wgpu::TextureUsage::OUTPUT_ATTACHMENT,
@@ -116,7 +113,8 @@ fn main() {
             glfw_platform.prepare_render(&ui, &mut window);
         }
 
-        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
+        let mut encoder =
+            device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
         imgui_renderer
             .render(ui.render(), &device, &mut encoder, &frame.view)
             .expect("render failed");

--- a/examples/demo_window.rs
+++ b/examples/demo_window.rs
@@ -1,4 +1,5 @@
 use std::time::Instant;
+use futures::executor::block_on;
 
 fn main() {
     let mut glfw = glfw::init(glfw::FAIL_ON_ERRORS).expect("GLFW failed to init");
@@ -14,25 +15,32 @@ fn main() {
 
     let surface = wgpu::Surface::create(&window);
 
-    let adapter = wgpu::Adapter::request(&wgpu::RequestAdapterOptions {
-        power_preference: wgpu::PowerPreference::HighPerformance,
-        backends: wgpu::BackendBit::PRIMARY,
-    })
-    .unwrap();
+    let adapter = block_on(
+        wgpu::Adapter::request(
+            &wgpu::RequestAdapterOptions {
+                power_preference: wgpu::PowerPreference::HighPerformance,
+                compatible_surface: Some(&surface)
+            },
+            wgpu::BackendBit::PRIMARY,
+        )
+    ).unwrap();
 
-    let (device, mut queue) = adapter.request_device(&wgpu::DeviceDescriptor {
-        extensions: wgpu::Extensions {
-            anisotropic_filtering: false,
-        },
-        limits: wgpu::Limits::default(),
-    });
+
+    let (device, mut queue) = block_on(
+        adapter.request_device(&wgpu::DeviceDescriptor {
+            extensions: wgpu::Extensions {
+                anisotropic_filtering: false,
+            },
+            limits: wgpu::Limits::default(),
+        })
+    );
 
     let mut swap_chain_desc = wgpu::SwapChainDescriptor {
         usage: wgpu::TextureUsage::OUTPUT_ATTACHMENT,
         format: wgpu::TextureFormat::Bgra8Unorm,
         width,
         height,
-        present_mode: wgpu::PresentMode::NoVsync,
+        present_mode: wgpu::PresentMode::Immediate,
     };
 
     let mut swap_chain = device.create_swap_chain(&surface, &swap_chain_desc);
@@ -92,7 +100,7 @@ fn main() {
             swap_chain = device.create_swap_chain(&surface, &swap_chain_desc);
         }
 
-        let frame = swap_chain.get_next_texture();
+        let frame = swap_chain.get_next_texture().unwrap();
         last_frame_time = imgui.io_mut().update_delta_time(last_frame_time);
 
         glfw_platform
@@ -108,7 +116,7 @@ fn main() {
             glfw_platform.prepare_render(&ui, &mut window);
         }
 
-        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
+        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
         imgui_renderer
             .render(ui.render(), &device, &mut encoder, &frame.view)
             .expect("render failed");

--- a/examples/demo_window_smooth_resize.rs
+++ b/examples/demo_window_smooth_resize.rs
@@ -1,4 +1,5 @@
 use std::time::Instant;
+use futures::executor::block_on;
 
 fn main() {
     let mut glfw = glfw::init(glfw::FAIL_ON_ERRORS).expect("GLFW failed to init");
@@ -14,25 +15,29 @@ fn main() {
 
     let surface = wgpu::Surface::create(&window);
 
-    let adapter = wgpu::Adapter::request(&wgpu::RequestAdapterOptions {
-        power_preference: wgpu::PowerPreference::HighPerformance,
-        backends: wgpu::BackendBit::PRIMARY,
-    })
-    .unwrap();
-
-    let (device, mut queue) = adapter.request_device(&wgpu::DeviceDescriptor {
-        extensions: wgpu::Extensions {
-            anisotropic_filtering: false,
+    let adapter = block_on(wgpu::Adapter::request(
+        &wgpu::RequestAdapterOptions {
+            power_preference: wgpu::PowerPreference::HighPerformance,
+            compatible_surface: None
         },
-        limits: wgpu::Limits::default(),
-    });
+        wgpu::BackendBit::PRIMARY,
+    )).unwrap();
+
+    let (device, mut queue) = block_on(adapter.request_device(
+        &wgpu::DeviceDescriptor {
+            extensions: wgpu::Extensions {
+                anisotropic_filtering: false,
+            },
+            limits: wgpu::Limits::default(),
+        }
+    ));
 
     let mut swap_chain_desc = wgpu::SwapChainDescriptor {
         usage: wgpu::TextureUsage::OUTPUT_ATTACHMENT,
         format: wgpu::TextureFormat::Bgra8Unorm,
         width,
         height,
-        present_mode: wgpu::PresentMode::NoVsync,
+        present_mode: wgpu::PresentMode::Immediate,
     };
 
     let mut swap_chain = device.create_swap_chain(&surface, &swap_chain_desc);
@@ -77,7 +82,7 @@ fn main() {
         let mut render_fn = |imgui: &mut imgui::Context,
                              window: &mut glfw::Window,
                              swap_chain: &mut wgpu::SwapChain| {
-            let frame = swap_chain.get_next_texture();
+            let frame = swap_chain.get_next_texture().unwrap();
             last_frame_time = imgui.io_mut().update_delta_time(last_frame_time);
 
             glfw_platform
@@ -94,7 +99,7 @@ fn main() {
             }
 
             let mut encoder =
-                device.create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
+                device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
             imgui_renderer
                 .render(ui.render(), &device, &mut encoder, &frame.view)
                 .expect("render failed");

--- a/examples/demo_window_smooth_resize.rs
+++ b/examples/demo_window_smooth_resize.rs
@@ -1,5 +1,5 @@
-use std::time::Instant;
 use futures::executor::block_on;
+use std::time::Instant;
 
 fn main() {
     let mut glfw = glfw::init(glfw::FAIL_ON_ERRORS).expect("GLFW failed to init");
@@ -18,19 +18,18 @@ fn main() {
     let adapter = block_on(wgpu::Adapter::request(
         &wgpu::RequestAdapterOptions {
             power_preference: wgpu::PowerPreference::HighPerformance,
-            compatible_surface: None
+            compatible_surface: None,
         },
         wgpu::BackendBit::PRIMARY,
-    )).unwrap();
+    ))
+    .unwrap();
 
-    let (device, mut queue) = block_on(adapter.request_device(
-        &wgpu::DeviceDescriptor {
-            extensions: wgpu::Extensions {
-                anisotropic_filtering: false,
-            },
-            limits: wgpu::Limits::default(),
-        }
-    ));
+    let (device, mut queue) = block_on(adapter.request_device(&wgpu::DeviceDescriptor {
+        extensions: wgpu::Extensions {
+            anisotropic_filtering: false,
+        },
+        limits: wgpu::Limits::default(),
+    }));
 
     let mut swap_chain_desc = wgpu::SwapChainDescriptor {
         usage: wgpu::TextureUsage::OUTPUT_ATTACHMENT,


### PR DESCRIPTION
propagate version bumps: imgui -> imgui-wgpu -> imgui-glfw-support

also uses a new version of wgpu 

"tested" here: https://github.com/dwbrite/imgui-wgpu-glfw-example